### PR TITLE
Fixed Colour and ColourRange parsing errors

### DIFF
--- a/Core/Colour.cs
+++ b/Core/Colour.cs
@@ -145,13 +145,13 @@ namespace MonoGameMPE.Core {
         /// </returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}°,{1:P0},{2:P0}", 
+            return string.Format(CultureInfo.InvariantCulture, "{0}°;{1:P0};{2:P0}", 
                 H.ToString("F1"), (100*S).ToString("F1"), (100*L).ToString("F1"));
         }
 
         public static Colour Parse(string s)
         {
-            var hsl = s.Split(',');
+            var hsl = s.Split(';');
             var hue = float.Parse(hsl[0].TrimEnd('°'));
             var sat = float.Parse(hsl[1]);
             var lig = float.Parse(hsl[2]);

--- a/Core/ColourRange.cs
+++ b/Core/ColourRange.cs
@@ -21,8 +21,8 @@ namespace MonoGameMPE.Core
             {
                 var noBrackets = value.Substring(1, value.Length - 2);
                 var colors = noBrackets.Split(';');
-                var c1 = Colour.Parse(colors[0]);
-                var c2 = Colour.Parse(colors[1]);
+                var c1 = Colour.Parse($"{colors[0]};{colors[1]};{colors[2]}");
+                var c2 = Colour.Parse($"{colors[3]};{colors[4]};{colors[5]}");
                 return new ColourRange(c1, c2);
             }
             catch


### PR DESCRIPTION
I just encountered some parsing errors in the Colour.cs and ColourRange.cs class.

**First fix:**
In the string override Colour.ToString() I changed the splitting char from comma to semicolon, because the comma is also used in floats in some cultures and the values H,S,L are defined in floats. 

The splitted string should have been something like "0.0°, 0.0, 0.0" but it came in like "0,0°, 0,0, 0,0" (notice the commata). 
string.Split(',') then created 6 different strings instead of 3, which resulted in float parsing errors in the next lines (and wrong values).

**Second fix:**
The Colour.Parse functions in ColorRange.Parse received only the HUE value and not the whole colour string.

---

I think these errors are only interesting when working in editor environments and I know that your project was merged with MonoGame.Extended, but I use your class library in one of my projects, that's why I wanted to mention it here.

Anyways, thanks for the MonoGame port of the Mercury Particle Engine 👍 